### PR TITLE
Fix setup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pixi add mojmelo
 
 To start the setup process, Run the following command from the `main folder` of your project:
 ```
-bash ./.pixi/envs/default/etc/conda/test-files/mojmelo/0/tests/setup.sh
+pixi run bash ./.pixi/envs/default/etc/conda/test-files/mojmelo/0/tests/setup.sh
 ```
 
 Note: If CPU cache details are available by your OS, benchmarking parts of the setup will be skipped. Otherwise, please try not to run other tasks on your pc during the process for better results.


### PR DESCRIPTION
The bash script needs to be run within the pixi environment.